### PR TITLE
Build images via Actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,55 @@
+name: docker-build
+
+on:
+  push:
+    branches:
+      - 'master'
+
+permissions: 
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout repository
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Docker requires image tags to be in all lowercase
+      -
+        id: username-format
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.repository_owner }}
+      -
+        name: Build and push (Alpine)
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: alpine.dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ steps.username-format.outputs.lowercase }}/cron:latest
+      -
+        name: Build and push (Ubuntu)
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ubuntu.dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ steps.username-format.outputs.lowercase }}/cron:ubuntu

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'master'
+  schedule:
+    - cron:  '35 2 * * 2'
 
 permissions: 
   packages: write


### PR DESCRIPTION
Build multi arch image (amd64, arm/v7, arm64)
Publish to GitHub Container Registry

The image will be tagged with the username of the repository's owner Useful when forks want to push their own versions to the registry

CentOS build is failing so it was excluded (who uses CentOS in 2023 anyways)
Ubuntu build is really slow (69s) compared to Alpine (12s)